### PR TITLE
Fix libarchive.js

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,14 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = { output: 'export', basePath: '/apm-web' };
+const nextConfig = {
+  output: 'export',
+  basePath: '/apm-web',
+  webpack: (config) => {
+    config.module.rules.push({
+      test: /worker-bundle\.js$/,
+      type: 'asset/source',
+    });
+    return config;
+  },
+};
 
 module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
   "devDependencies": {
     "@types/bootstrap": "^5.2.10",
     "@types/encoding-japanese": "^2.2.1",
-    "@types/libarchive.js": "^1.3.4",
     "@types/node": "^22.8.4",
     "@types/path-browserify": "^1.0.3",
     "@types/react": "^18.3.12",

--- a/src/app/components/ArchiveComponent.tsx
+++ b/src/app/components/ArchiveComponent.tsx
@@ -3,8 +3,10 @@ import { useDropzone } from 'react-dropzone';
 import JSZip from 'jszip';
 import VirtualInstallation from './VirtualInstallation';
 import Encoding from 'encoding-japanese';
-import { Archive } from 'libarchive.js/main.js';
-import { CompressedFile } from 'libarchive.js/src/compressed-file';
+import { Archive } from 'libarchive.js';
+import type { CompressedFile } from 'libarchive.js/src/compressed-file';
+
+type FileData = { file: CompressedFile; path: string };
 
 const splitUrl = window.location.href.split('/');
 const workerBaseUrl =
@@ -92,17 +94,15 @@ function ArchiveComponent(props: {
 
               // L-SMASH_Works_r940_plugins can't be extracted, but the file list can be read.
               // Therefore, loading is done in two steps.
-              for (const file of await archive.getFilesArray()) {
-                const compressedFile = file.file as CompressedFile;
-                files[compressedFile._path] = '';
+              for (const f of (await archive.getFilesArray()) as FileData[]) {
+                files[f.path + f.file.name] = '';
               }
               try {
-                for (const file of await archive.getFilesArray()) {
-                  const compressedFile = file.file as CompressedFile;
+                for (const f of (await archive.getFilesArray()) as FileData[]) {
                   const buffer = await arrayBufferFromFile(
-                    await compressedFile.extract(),
+                    await f.file.extract(),
                   );
-                  files[compressedFile._path] =
+                  files[f.path + f.file.name] =
                     await getSriFromArrayBuffer(buffer);
                 }
               } catch (e) {

--- a/src/app/components/ArchiveComponent.tsx
+++ b/src/app/components/ArchiveComponent.tsx
@@ -4,7 +4,7 @@ import JSZip from 'jszip';
 import VirtualInstallation from './VirtualInstallation';
 import Encoding from 'encoding-japanese';
 import { Archive } from 'libarchive.js';
-import type { CompressedFile } from 'libarchive.js/src/compressed-file';
+import type { CompressedFile } from 'libarchive.js/dist/build/compiled/compressed-file';
 
 type FileData = { file: CompressedFile; path: string };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -198,11 +198,6 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
 
-"@types/libarchive.js@^1.3.4":
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/@types/libarchive.js/-/libarchive.js-1.3.4.tgz#54bae138f3c223b4ebb5a77ecb22f71cc14465a2"
-  integrity sha512-NivcQAJU1mcnnZjfxcx0WMJ++u5BmiDFEfhx5/JM9wojDq3nnW+7T+4onmx0BUxh+3F28aOvUCF/VyUFhSPGLQ==
-
 "@types/node@^22.8.4":
   version "22.8.4"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-22.8.4.tgz#ab754f7ac52e1fe74174f761c5b03acaf06da0dc"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

fix libarchive.js

- libarchive.js now uses TypeScript.
- fix type errors.
- change not to run webpack for worker-bundle.js
- patch for libarchive.js

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
