### PR TITLE
ci: ワークフローを apm と同じ水準に揃える

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -22,6 +22,13 @@ on:
     - cron: '43 19 * * 5'
   workflow_dispatch:
 
+# Cancel superseded runs for the same pull request. Pushes are not cancelled:
+# every commit on the default branch needs to keep its own Actions status, and
+# a burst of merges would otherwise discard the earlier ones.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,9 +14,10 @@ name: 'CodeQL'
 on:
   push:
     branches: [main]
+  # Do not restrict the base to main: pull requests targeting an intermediate
+  # branch (a stacked pull request) must be checked too. The branches filter
+  # matches the base, not the head, so restricting it leaves them unverified.
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [main]
   schedule:
     - cron: '43 19 * * 5'
   workflow_dispatch:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -20,17 +20,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Setup Pages
-        uses: actions/configure-pages@v5
-      - uses: actions/setup-node@v6
+        uses: actions/configure-pages@v6
+      - uses: actions/setup-node@v7
         with:
           node-version: 'lts/*'
           cache: yarn
       - run: yarn install --frozen-lockfile
       - run: yarn build
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: out/apm-web/
 
@@ -44,4 +44,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -9,6 +9,13 @@ on:
   pull_request:
   workflow_dispatch:
 
+# Cancel superseded runs for the same pull request. Pushes are not cancelled:
+# every commit on the default branch needs to keep its own Actions status, and
+# a burst of merges would otherwise discard the earlier ones.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -21,8 +21,8 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
         with:
           node-version: 'lts/*'
           cache: yarn

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -3,8 +3,10 @@ name: Node CI
 on:
   push:
     branches: [main]
+  # Do not restrict the base to main: pull requests targeting an intermediate
+  # branch (a stacked pull request) must be checked too. The branches filter
+  # matches the base, not the head, so restricting it leaves them unverified.
   pull_request:
-    branches: [main]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## 何を

`nodejs.yml` / `codeql-analysis.yml` / `gh-pages.yml` に 3 つの変更を入れます。コミットは 1 つずつ分けてあります。

1. `pull_request` の `branches: [main]` を撤去
2. `concurrency` を追加(PR の古い実行だけ打ち切る。push と deploy は対象外)
3. actions のバージョンを更新

## なぜ

### 1. base フィルタ

`pull_request` の `branches` フィルタは **head ではなく base** を見ます。`[main]` に限定していると、中間ブランチ宛ての PR(stacked PR)にはどのワークフローもトリガされず、**チェックが 1 つも走らないままマージできます**。フィルタの見た目とは逆の効果です。team-apm/apm でも team-apm/apm#2443 で同じ修正をしています。

### 2. concurrency

base フィルタを外すと stacked PR の分だけ実行が増えるため、連続 push で同じ ref に古い実行が残ります。push を対象外にしているのは、main の各コミットについて Actions のステータスを残す必要があるためです。

**`gh-pages.yml` には入れていません。** Pages のデプロイを直列化するのは CI ではなくデプロイ挙動の変更なので、別の変更として扱うべきだと判断しました(GitHub の Pages スターターワークフローは `group: 'pages'` / `cancel-in-progress: false` を推奨しています。必要なら別 PR で)。

### 3. actions のバージョン

これは単なる更新ではなく、**dependabot が止まっている兆候**として見つけたものです。

| リポジトリ | 最新の dependabot PR | checkout | setup-node |
| --- | --- | --- | --- |
| apm | 2026-08-09 | v7 | v7 |
| apm-data | 2026-08-19 | v7 | v7 |
| apm-schema | 2026-04-10 | v6 | v6 |
| **apm-web** | **2026-04-14** | v6 | v6 |

`flatted 3.3.3 → 3.4.2` は 2026-03-21 に 4 リポジトリ同時に出ています。それ以降 apm / apm-data には更新が来続けているのに、apm-web には 1 本も来ていません。[GitHub のドキュメント](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates)に「When maintainers of a repository stop interacting with Dependabot pull requests, Dependabot temporarily pauses its updates.」とあり、ここでは 11 本が反応の無いまま開いています。

上げたもの:

| action | 変更 | 中身 |
| --- | --- | --- |
| `actions/checkout` | v6 → v7 | |
| `actions/setup-node` | v6 → v7 | |
| `actions/configure-pages` | v5 → v6 | Node 24 化のみ(#804 と同じ) |
| `actions/deploy-pages` | v4 → v5 | Node 24 化のみ(#803 と同じ) |
| `actions/upload-pages-artifact` | v4 → v5 | Node 24 化 + upload-artifact v7 化(#806 と同じ) |

Pages 系 3 つのリリースノートを確認しましたが、いずれも**ランタイムの Node 化のみで機能的な破壊的変更はありません**。デプロイの挙動は今のままです。

**#803 / #804 / #806 はこれで不要になるので、マージ後に閉じられます。**

## 確認したこと

- `yarn lint`(prettier + next lint)が緑
- `yarn install --frozen-lockfile` が `yarn.lock` を汚さないことを確認

## 補足: セキュリティアラートについて

このリポジトリには open な dependabot alert が 51 件(critical 2 / high 26)あります。ただし **`next.config.ts` が `output: 'export'` で静的エクスポートしている**ため、Next.js のサーバー側 CVE(React flight protocol の RCE、rewrites の SSRF、Server Actions の DoS、middleware バイパス等)は**公開中のサイトには当たりません** — Next.js サーバーが動いていないためです。影響するのはビルド時と `next dev` を動かす開発機です。

依存の一括更新は別 PR で扱います。