### PR TITLE
build(deps): dependabot の設定を apm と同じ水準に揃える

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,26 @@ updates:
   - package-ecosystem: 'npm' # See documentation for possible values
     directory: '/' # Location of package manifests
     schedule:
-      interval: 'daily'
+      # Weekly rather than daily: a single maintainer cannot keep up with a
+      # daily stream, and unreviewed pull requests accumulate until Dependabot
+      # pauses its own updates for the repository.
+      interval: 'weekly'
+    open-pull-requests-limit: 5
+    ignore:
+      # Majors are taken deliberately, one major per pull request. Listed by
+      # name rather than as '*' because ignore conditions also suppress
+      # Dependabot security updates, and a blanket rule would hide a fix that
+      # only ships in a new major.
+      - dependency-name: 'next'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'react'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'react-dom'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'eslint'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'typescript-eslint'
+        update-types: ['version-update:semver-major']
     groups:
       next:
         patterns:
@@ -23,11 +42,18 @@ updates:
         patterns:
           - '@eslint/*'
           - 'eslint*'
+      typescript-eslint:
+        patterns:
+          - 'typescript-eslint'
       prettier:
         patterns:
           - 'prettier*'
+      types:
+        patterns:
+          - '@types/*'
 
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
+    open-pull-requests-limit: 2


### PR DESCRIPTION
## 何を

`.github/dependabot.yml` を apm と同じ運用水準に揃えます。

| 項目 | 変更前 | 変更後 |
| --- | --- | --- |
| `interval` | `daily` | `weekly` |
| `open-pull-requests-limit` (npm) | 未設定(既定 5) | `5` を明示 |
| `open-pull-requests-limit` (actions) | 未設定(既定 5) | `2` |
| major の `ignore` | 無し | `next` / `react` / `react-dom` / `eslint` / `typescript-eslint` |
| `groups` | next / react / eslint / prettier | + typescript-eslint / `@types/*` |

## なぜ

### 頻度と上限

apm の `dependabot.yml` には理由がコメントで書かれています — **「1人運用で追い切れる頻度に抑える(daily だと PR が滞留する)」**。この判断がここへ持ち込まれておらず、`daily` のままでした。

その結果がこれです。**2026-04-14 を最後に dependabot の PR が 1 本も来ていません。** 同じ依存(`flatted 3.3.3 → 3.4.2`)が 2026-03-21 に 4 リポジトリ同時に出ているのに、apm と apm-data には 8 月まで来続けているのに対し、ここは止まっています。GitHub は「メンテナが dependabot PR に反応しなくなると version updates を一時停止する」と明記しており、ここでは 11 本が無反応のまま開いています。

**設定を直さないまま PR を閉じても、また同じところへ戻ります。**

### `@types/*` のグループ化

`@types/node` は 10 月 1 日〜29 日の間に **8 回**上げられ、**8 本とも未マージで閉じられています**。1 本にまとめます。

### major を除外する理由と、`'*'` にしない理由

メジャー更新は「1 PR = 1 major」で計画的に上げる方針(apm の AGENTS.md)に合わせ、dependabot からは外します。

`next` と `react` を含めたのは**すでに実態がそうだから**です — next 16 への更新 PR は 2026-03-21 に開かれ、未マージで閉じられています。

ただし **`ignore` はパッケージ名で列挙し、`dependency-name: '*'` は使いません**。GitHub の[ドキュメント](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file)によれば `ignore` は version updates だけでなく **security updates にも適用される**ため、`'*'` で major を一括除外すると「新しい major でしか出ない修正」まで隠れてしまいます。

## 影響しないもの

- **dependabot の security updates は別機能**なので、この変更で止まりません
- 既に開いている PR には影響しません(別途処理します)

## 関連

CI の統一は team-apm/apm-web#807 で出しています。滞留している dependabot PR 11 本の処理と、`ncu` による依存の一括更新(next 15.3.3 → 15.5.x を含む)は別途。