### PR TITLE
build(deps): @eslint/* と eslint-config-next の major も ignore に含める

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,11 +20,19 @@ updates:
       # only ships in a new major.
       - dependency-name: 'next'
         update-types: ['version-update:semver-major']
+      # eslint-config-next tracks next's major, and it shares a group with it,
+      # so leaving it out lets the group carry a next 16 config against next 15.
+      - dependency-name: 'eslint-config-next'
+        update-types: ['version-update:semver-major']
       - dependency-name: 'react'
         update-types: ['version-update:semver-major']
       - dependency-name: 'react-dom'
         update-types: ['version-update:semver-major']
       - dependency-name: 'eslint'
+        update-types: ['version-update:semver-major']
+      # @eslint/js and @eslint/eslintrc ship in lockstep with eslint, so
+      # ignoring only the latter lets a major land on one half of the pair.
+      - dependency-name: '@eslint/*'
         update-types: ['version-update:semver-major']
       - dependency-name: 'typescript-eslint'
         update-types: ['version-update:semver-major']


### PR DESCRIPTION
## 何を

`.github/dependabot.yml` の `ignore` に 2 つ追加します。

- `@eslint/*`(`@eslint/js` と `@eslint/eslintrc`)
- `eslint-config-next`

## なぜ

team-apm/apm-web#808 で `eslint` と `next` の major を除外しましたが、**同時にリリースされる相方を入れ忘れていました**。

### `@eslint/*`

`@eslint/js` と `@eslint/eslintrc` は `eslint` と同じバージョンで出ます。apm-data で同じ設定を入れた数時間後、dependabot が実際にこの穴を突いてきました([team-apm/apm-data#1004](https://github.com/team-apm/apm-data/pull/1004))。

```diff
-    "@eslint/js": "^9.39.5",
+    "@eslint/js": "^10.0.1",
```

`eslint` は 9 のまま残ります。

### `eslint-config-next`

こちらはもう少し厄介です。`eslint-config-next` は `next` の major に追随し、しかも **dependabot の `next` グループに同居**しています。ignore が無いと、グループ PR が **next 15 のプロジェクトに next 16 用の設定**を持ち込めてしまいます。

このリポジトリは `sharp` と `postcss` の alert が next 16 待ちで、まだ next 15 に留まる必要があるため、この組み合わせは避けたいところです。

## 関連

apm-data は team-apm/apm-data#1010、apm-schema は team-apm/apm-schema#356 です。